### PR TITLE
added an option for generators to observe static fluents in traces.

### DIFF
--- a/macq/extract/learned_action.py
+++ b/macq/extract/learned_action.py
@@ -27,7 +27,8 @@ class LearnedAction:
         return hash(self.details())
 
     def details(self):
-        # obj_params can be either a list of strings or a list of PlanningObject depending on the token type and extraction method used to learn the action
+        # obj_params can be either a list of strings or a list of PlanningObject
+        # depending on the token type and extraction method used to learn the action
         try:
             string = f"({self.name} {' '.join(self.obj_params)})"
         except TypeError:
@@ -139,8 +140,8 @@ class LearnedLiftedAction:
             fluents = {fluents}
         self.precond.update(fluents)
 
-    def update_add(self, fluents: Union[LearnedLiftedFluent, Set[LearnedLiftedFluent], FullyHashedLearnedLiftedFluent, Set[
-                FullyHashedLearnedLiftedFluent]]):
+    def update_add(self, fluents: Union[LearnedLiftedFluent, Set[
+            LearnedLiftedFluent], FullyHashedLearnedLiftedFluent, Set[FullyHashedLearnedLiftedFluent]]):
         """Adds add effects to the action.
 
         Args:

--- a/macq/extract/sam.py
+++ b/macq/extract/sam.py
@@ -1,6 +1,8 @@
-from macq.trace import Action, Fluent, State, SAS, TraceList, Trace
+import macq.observation
+from macq.trace import Action, Fluent, State, SAS
 from macq.extract import model, LearnedLiftedAction
 from macq.extract.learned_fluent import LearnedLiftedFluent, FullyHashedLearnedLiftedFluent
+from macq.observation import ObservedTraceList, ActionObservation
 
 
 class FluentInfo:
@@ -25,7 +27,7 @@ class SAMgenerator:
     an object that handles all traces data and manipulates it in order to generate a model based on SAM algorithm
     """
     fluents: set[Fluent] = set()  # list of all fluents collected from all traces
-    trace_list: TraceList = TraceList()
+    obs_trace_list: ObservedTraceList
     L_bLA: dict[str, set[FluentInfo]] = dict()  # represents all parameter bound literals mapped by action
     effA_add: dict[str, set[FluentInfo]] = dict()  # dict like preA that holds delete and add biding for each action
     # name
@@ -34,27 +36,25 @@ class SAMgenerator:
     #  add is 0 index in tuple and delete is 1
     preA: dict[str, set[FluentInfo]] = dict()  # represents  parameter bound literals mapped by action, of pre-cond
     # LiftedPreA, LiftedEFF both of them are stets of learned lifted fluents
-    action_triplets: set[SAS] = set()
     learned_lifted_fluents: set[LearnedLiftedFluent] = set()
     learned_lifted_action: set[LearnedLiftedAction] = set()
     action_2_sort: dict[str, list[str]] = dict()  # TODO use when knowing how to sort action
 
     # =======================================Initialization of data structures======================================
-    def __init__(self, trace_list: TraceList = None,
+    def __init__(self, obs_trace_list: ObservedTraceList = None,
                  action_2_sort: dict[str, list[str]] = None):
         """Creates a new SAMgenerator instance.
                Args:
-                    trace_list(TraceList):
-                        an object holding a list of traces from the same domain.
+                    obs_trace_list(ObservedTraceList):
+                        observed traces from the same domain.
                     action_2_sort(dict str -> list[str])
                 """
-        self.trace_list = trace_list
-        if trace_list is not None:
-            self.trace_list = trace_list
-            self.fluents = self.trace_list.get_fluents()
-            self.update_action_triplets(self.trace_list.traces)
+        self.obs_trace_list = obs_trace_list
+        if obs_trace_list is not None:
+            self.obs_trace_list = obs_trace_list
+            self.fluents = self.obs_trace_list.get_fluents()
             self.action_2_sort = action_2_sort
-            self.update_L_bLA(trace_list.traces)
+            self.update_L_bLA()
 
     def make_act_sorts(self):
         """sorts all actions parameter types"""
@@ -62,69 +62,54 @@ class SAMgenerator:
         pass
 
     # =======================================UPDATE FUNCTIONS========================================================
-    def update_action_triplets(self, traces: list[Trace]):
-        for trace in traces:
-            for act in trace.actions:
-                self.action_triplets.update(set(trace.get_sas_triples(act)))
-
-    def update_trace_list(self, trace_list: TraceList):
-        for trace in trace_list.traces:
-            self.trace_list.insert(trace_list.__len__(), trace)
-        self.update_action_triplets(trace_list.traces)
-        self.update_L_bLA(trace_list.traces)
-
-    def update_L_bLA(self, traces: list[Trace]):
+    def update_L_bLA(self):
         """collects all parameter bound literals and maps them based on action name
                 values of dict is a set[(fluent.name: str, sorts:list[str], param_inds:set[int])]"""
-        for trace in traces:  # for every trace in the trace list
-            for act in trace.actions:  # for every act in the trace
-                if isinstance(act, Action):
-                    if not self.L_bLA.keys().__contains__(act.name):  # if act name not already id the dictionary
-                        self.L_bLA[act.name] = set()  # initiate its set
+        actions_in_traces: set[Action] = self.obs_trace_list.get_actions()
+        for f in self.obs_trace_list.get_fluents():  # for every fluent in the acts fluents
+            for act in actions_in_traces:
+                if not self.L_bLA.keys().__contains__(act.name):
+                    self.L_bLA[act.name] = set()
+                param_indexes_in_literal: list[int] = list()  # initiate a set of ints
+                sorts: list[str] = list()
 
-                    a: set[Fluent] = set() if act.precond is None else act.precond
-                    b: set[Fluent] = set() if act.add is None else act.add
-                    c: set[Fluent] = set() if act.delete is None else act.delete
-                    f_set = set().union(a, b, c)
-                    for f in f_set:  # for every fluent in the acts fluents
-                        param_indexes_in_literal: list[int] = list()  # initiate a set of ints
-                        sorts: list[str] = list()
-                        i: int = 0
-                        for obj in act.obj_params:  # for every object in the parameters
-                            # TODO change when knowing how to sort types
-                            if f.objects.__contains__(obj):  # if the object is true in fluent then
-                                param_indexes_in_literal.append(i)  # append obj index to
-                                sorts.append(self.action_2_sort[act.name].__getitem__(i))
-                            i += 1
-                        self.L_bLA[act.name].add(FluentInfo(f.name, sorts, param_indexes_in_literal))
+                if all(act.obj_params.__contains__(ob) for ob in f.objects):  # check to see if all fluent objects are
+                    # bound to action parameters
+                    i: int = 0
+                    for obj in act.obj_params:  # for every object in the parameters
+                        # TODO change when knowing how to sort types
+                        if f.objects.__contains__(obj):  # if the object is true in fluent then
+                            param_indexes_in_literal.append(i)  # append obj index to
+                            sorts.append(self.action_2_sort[act.name].__getitem__(i))  # append obj sort
+                        i += 1
+                    self.L_bLA[act.name].add(FluentInfo(f.name, sorts, param_indexes_in_literal))
         self.preA = self.L_bLA.copy()
 
-    def update_action_2_sort(self, action_2_sort: dict[str, list[str]]):
-        """inserts key and value, replaces value of key already if key already in dict"""
-        self.action_2_sort.update(action_2_sort)
-
     # =======================================ALGORITHM LOGIC========================================================
-    def remove_redundant_preconditions(self, sas: SAS):  # based on lines 6 to 8 in paper
+    def remove_redundant_preconditions(self, act: Action, transitions: list[list[macq.observation.Observation]]):
+        # based on lines 6 to 8 in paper
         """removes all parameter-bound literals that there groundings are not pre-state"""
-        act: Action = sas.action
-        pre_state: State = sas.pre_state
-        to_remove: set[FluentInfo] = set()
-        for flu_inf in self.preA[act.name]:
-            fluent = Fluent(flu_inf.name, [obj for obj in act.obj_params if flu_inf.param_act_inds.__contains__(
-                act.obj_params.index(obj))])  # make a fluent instance so we can use eq function
-            if (pre_state.fluents.keys().__contains__(fluent)) and not pre_state.fluents[fluent]:  # remove if
-                # unbound or if not true, means, preA contains at the end only true value fluents
-                to_remove.add(flu_inf)
-        for flu_inf in to_remove:
-            self.preA[act.name].remove(flu_inf)
+        for trans in transitions:
+            pre_state: State = trans[0].state
+            to_remove: set[FluentInfo] = set()
+            for flu_inf in self.preA[act.name]:
+                fluent = Fluent(flu_inf.name, [obj for obj in act.obj_params if flu_inf.param_act_inds.__contains__(
+                    act.obj_params.index(obj))])  # make a fluent instance so we can use eq function
+                if (pre_state.fluents.keys().__contains__(fluent)) and not pre_state.fluents[fluent]:  # remove if
+                    # unbound or if not true, means, preA contains at the end only true value fluents
+                    to_remove.add(flu_inf)
+            for flu_inf in to_remove:
+                self.preA[act.name].remove(flu_inf)
 
-    def add_surely_effects(self, sas: SAS):  # based on lines 9 to 11 in paper
+    def add_surely_effects(self, act: Action, transitions: list[list[macq.observation.Observation]]):  # based on lines 9 to 11 in paper
         """add all parameter-bound literals that are surely an effect"""
-        act: Action = sas.action
-        # add all add_effects of parameter bound literals
-        self.add_literal_binding_to_eff(sas.post_state, sas.pre_state, act, add_delete="add")
-        # add all delete_effects of parameter bound literals
-        self.add_literal_binding_to_eff(sas.pre_state, sas.post_state, act, add_delete="delete")
+        for trans in transitions:
+            pre_state: State = trans[0].state
+            post_state: State = trans[1].state
+            # add all add_effects of parameter bound literals
+            self.add_literal_binding_to_eff(post_state, pre_state, act, add_delete="add")
+            # add all delete_effects of parameter bound literals
+            self.add_literal_binding_to_eff(pre_state, post_state, act, add_delete="delete")
 
     def add_literal_binding_to_eff(self, s1: State, s2: State, act: Action,
                                    add_delete="add"):
@@ -174,10 +159,11 @@ class SAMgenerator:
     def loop_over_action_triplets(self):
         """implement lines 5-11 in the SAM paper
         calls dd_surely_effects and remove_redundant_preconditions to make pre-con(A) , Eff(A)"""
-
-        for sas in self.action_triplets:  # sas is state-action-state
-            self.remove_redundant_preconditions(sas)
-            self.add_surely_effects(sas)
+        self.obs_trace_list.get_all_transitions()
+        for act, transitions in self.obs_trace_list.get_all_transitions().items():  # sas is state-action-state
+            if isinstance(act, Action):
+                self.remove_redundant_preconditions(act, transitions)
+                self.add_surely_effects(act, transitions)
 
     # =======================================finalize and return a model============================================
     def make_act_lifted_fluent_set(self, act_name: str,
@@ -259,7 +245,7 @@ class SAMgenerator:
 class SAM:
     __sam_generator = None
 
-    def __new__(cls, types: set[str] = None, trace_list: TraceList = None,
+    def __new__(cls, obs_trace_list: ObservedTraceList = None,
                 action_2_sort: dict[str, list[str]] = None, sam_generator: SAMgenerator = None):
         """Creates a new SAM instance. if input includes sam_generator object than it uses the object provided
         instead of creating a new one
@@ -275,6 +261,6 @@ class SAM:
         if sam_generator is not None:
             cls.__sam_generator = sam_generator
         else:
-            cls.__sam_generator: SAMgenerator = SAMgenerator(trace_list=trace_list, action_2_sort=action_2_sort)
+            cls.__sam_generator: SAMgenerator = SAMgenerator(obs_trace_list=obs_trace_list, action_2_sort=action_2_sort)
 
         return cls.__sam_generator.generate_model()

--- a/macq/generate/pddl/trace_from_goal.py
+++ b/macq/generate/pddl/trace_from_goal.py
@@ -8,6 +8,7 @@ class TraceFromGoal(Generator):
         prob: str = None,
         problem_id: int = None,
         observe_pres_effs: bool = False,
+        observe_static_fluents: bool = False
     ):
         """
         Initializes a goal state trace sampler using the domain and problem. This method of sampling
@@ -28,6 +29,7 @@ class TraceFromGoal(Generator):
             prob=prob,
             problem_id=problem_id,
             observe_pres_effs=observe_pres_effs,
+            observe_static_fluents=observe_static_fluents
         )
         self.trace = self.generate_trace()
 

--- a/macq/trace/trace.py
+++ b/macq/trace/trace.py
@@ -6,6 +6,8 @@ from warnings import warn
 from rich.table import Table
 from rich.text import Text
 from rich.console import Console
+
+import macq.trace
 from . import Action, Step, State
 from ..observation import Observation, NoisyPartialDisorderedParallelObservation
 from ..utils import TokenizationError


### PR DESCRIPTION
<!-- Change ## at the end of the url to the pull request number -->
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/haz/03ac305b42d7c9ad4ef3213341bf3f2f/raw/macq__pull_##.json?cacheSeconds=3600)

* sam implemented with observations.
* added genrator of traces the abillity to observe static predicates.
* tests changed accordingly